### PR TITLE
Regexp rules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,8 +141,7 @@ There are some known limitations of the current implementation:
 * ``match-case`` filter option is not properly supported (it is ignored);
 * ``document`` filter option is not properly supported;
 * rules are not validated *before* parsing, so invalid rules may raise
-  inconsistent exceptions or silently work incorrectly;
-* regular expressions in rules are not supported.
+  inconsistent exceptions or silently work incorrectly.
 
 It is possible to remove all these limitations. Pull requests are welcome
 if you want to make it happen sooner!

--- a/adblockparser/parser.py
+++ b/adblockparser/parser.py
@@ -221,6 +221,10 @@ class AdblockRule(object):
             raise ValueError("Invalid rule")
             # return rule
 
+        # Check if the rule isn't already regexp
+        if rule.startswith('/') and rule.endswith('/'):
+            return rule[1:-1]
+
         # escape special regex characters
         rule = re.sub(r"([.$+?{}()\[\]\\])", r"\\\1", rule)
 

--- a/adblockparser/parser.py
+++ b/adblockparser/parser.py
@@ -223,7 +223,10 @@ class AdblockRule(object):
 
         # Check if the rule isn't already regexp
         if rule.startswith('/') and rule.endswith('/'):
-            return rule[1:-1]
+            rule = rule[1:-1]
+            if not rule:
+                raise ValueError('Invalid rule')
+            return rule
 
         # escape special regex characters
         rule = re.sub(r"([.$+?{}()\[\]\\])", r"\\\1", rule)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -282,3 +282,8 @@ def test_rules_instantiation():
 def test_empty_rule():
     rules = AdblockRules(["adv", "", " \t", AdblockRule("adv2")])
     assert len(rules.rules) == 2
+
+
+def test_empty_regexp_rules():
+    with pytest.raises(ValueError):
+        AdblockRules(['adv', '/', '//'])

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -257,10 +257,7 @@ def test_rules_with_options(rules, results, use_re2):
         assert rules.should_block(url, params) == should_block
 
 
-@pytest.mark.xfail
 def test_regex_rules():
-    # Regex rules are not supported yet.
-    # There are no such rules in EasyList filters.
     rules = AdblockRules(["/banner\d+/"])
     assert rules.should_block("banner123")
     assert not rules.should_block("banners")


### PR DESCRIPTION
This pull request add missing support for regexp rules. Please see the doc for details:
https://adblockplus.org/en/filters#regexps