### PR TITLE
Update EasyList project URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ On OS X you can get it using homebrew (``brew install re2``).
 
 .. _re2: https://github.com/google/re2
 .. _pyre2: https://github.com/axiak/pyre2
-.. _EasyList: https://easylist.adblockplus.org/en/
+.. _EasyList: https://easylist.to/
 
 Usage
 -----


### PR DESCRIPTION
The EasyList project is not hosted and not available at easylist.adblockplus.org anymore.