### PR TITLE
Fix option splitting on regex rules with end of line

### DIFF
--- a/adblockparser/parser.py
+++ b/adblockparser/parser.py
@@ -98,7 +98,7 @@ class AdblockRule(object):
                 rule_text = rule_text[2:]
 
         if not self.is_comment and '$' in rule_text:
-            rule_text, options_text = rule_text.split('$', 1)
+            rule_text, options_text = rule_text.rsplit('$', 1)
             self.raw_options = self._split_options(options_text)
             self.options = dict(self._parse_option(opt) for opt in self.raw_options)
         else:


### PR DESCRIPTION
While doing more extensive testing on my fork, I found a small bug. 

On the rule:

```
/\.accountant\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
```

taken from easylist, you split on the first `$`, then strip the left and right `/`, which leaves `\` at the end (which is an invalid regexp). It happens to not error out during regex compilation because it is followed by a `|` (I think), which can be properly escaped.

See [this snippet for ubo's implementation](https://github.com/gorhill/uBlock/blob/3ee25537a1f3584488e8a8d093f0092c1c88f1a1/src/js/static-net-filtering.js#L1645)